### PR TITLE
Make compatible with Chrome

### DIFF
--- a/src/destylize.js
+++ b/src/destylize.js
@@ -1,6 +1,6 @@
 const scanner = new Scanner();
 
-browser.runtime.onMessage.addListener(message => {
+chrome.runtime.onMessage.addListener(message => {
     switch (message.what) {
         case "send_status_updates":
             scanner.send_replacement_count();
@@ -38,6 +38,6 @@ function local_storage_change(changes, area) {
     }
 }
 
-browser.storage.onChanged.addListener(local_storage_change);
-browser.storage.local.get("enabled", value => set_enabled(value.enabled));
+chrome.storage.onChanged.addListener(local_storage_change);
+chrome.storage.local.get("enabled", value => set_enabled(value.enabled));
 console.log("Destylize initialized");

--- a/src/popup.html
+++ b/src/popup.html
@@ -15,7 +15,7 @@
       <p id="counter">…</p>
     </div> 
     <div class="row-container" id="toggle-button-container"> 
-      <button type="button" id="enable-toggle" onclick="enabled_toggled()">Start</button>
+      <button type="button" id="enable-toggle">Start</button>
     </div>
   </div>
 </body>

--- a/src/popup.js
+++ b/src/popup.js
@@ -43,25 +43,25 @@ function update() {
 }
 
 function request_send_status_updates() {
-    browser.tabs.query({
+    chrome.tabs.query({
         currentWindow: true,
         active: true
-    }).then(tabs => {
+    }, tabs => {
         if (tabs.length > 0) {
             active_tab_id = tabs[0].id;
-            browser.tabs.sendMessage(active_tab_id, {what: "send_status_updates"});
+            chrome.tabs.sendMessage(active_tab_id, {what: "send_status_updates"});
         }
     });
 }
 
 function request_halt_status_updates() {
-    browser.tabs.sendMessage(active_tab_id, {what: "halt_status_updates"});
+    chrome.tabs.sendMessage(active_tab_id, {what: "halt_status_updates"});
     active_tab_id = null;
 }
 
 function set_enabled(enabled) {
     if (enabled != cached_enabled) {
-        browser.storage.local.set({enabled: enabled});
+        chrome.storage.local.set({enabled: enabled});
         cached_enabled = enabled;
         update();
         request_send_status_updates(); // if enabling/disabling triggers a reload, updates will stop
@@ -76,9 +76,9 @@ window.onload = function(){
     update();
     request_send_status_updates();
 
-    browser.runtime.onMessage.addListener(process_message);
+    chrome.runtime.onMessage.addListener(process_message);
 
-    browser.storage.local.get("enabled", value => {
+    chrome.storage.local.get("enabled", value => {
         let enabled = ("enabled" in value) ? value.enabled : true;
         console.log("Enabled initially read as " + enabled);
         cached_enabled = enabled;
@@ -89,7 +89,7 @@ window.onload = function(){
 };
 
 window.onUnload = function(){
-    browser.runtime.onMessage.removeListener(process_message);
+    chrome.runtime.onMessage.removeListener(process_message);
     request_halt_status_updates();
     replacements = null;
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -55,8 +55,10 @@ function request_send_status_updates() {
 }
 
 function request_halt_status_updates() {
-    chrome.tabs.sendMessage(active_tab_id, {what: "halt_status_updates"});
-    active_tab_id = null;
+    if (active_tab_id) {
+        chrome.tabs.sendMessage(active_tab_id, {what: "halt_status_updates"});
+        active_tab_id = null;
+    }
 }
 
 function set_enabled(enabled) {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -90,7 +90,7 @@ class Scanner {
 
     send_replacement_count() {
         this.on_replacements_change = function() {
-            browser.runtime.sendMessage({what: "replacements", replacements: this.replacements});
+            chrome.runtime.sendMessage({what: "replacements", replacements: this.replacements});
         };
         this.on_replacements_change();
     }


### PR DESCRIPTION
Mostly by using the `chrome.*` API instead of the `browser.*` API (because a generically named API is specific to one browser, but an API named after one browser is cross-browser compatible. Yay web!)