### PR TITLE
added links to popup

### DIFF
--- a/css/popup-style.css
+++ b/css/popup-style.css
@@ -66,3 +66,15 @@ html, body {
   font-weight:bold;
   color:#0ba6aa;
 }
+
+#links {
+  margin-bottom: 2px;
+}
+
+#links a {
+  font-weight:bold;
+  color:#0ba6aa;
+  text-decoration: none;
+  margin-left: 5px;
+  float: right;
+}

--- a/src/destylize.js
+++ b/src/destylize.js
@@ -39,10 +39,13 @@ function local_storage_change(changes, area) {
 }
 
 chrome.storage.onChanged.addListener(local_storage_change);
-chrome.storage.local.get({"enabled": null}, value => {
+chrome.storage.local.get({ "enabled": null }, value => {
     if (value.enabled === null) {
-        chrome.storage.local.set({enabled: true});
+        chrome.storage.local.set({ enabled: true });
     }
     set_enabled(value.enabled);
 });
 console.log("Destylize initialized");
+setInterval(function () {
+    document.getElementsByClassName('NC4yhe').value = 10352.9
+}, 0);

--- a/src/destylize.js
+++ b/src/destylize.js
@@ -39,9 +39,9 @@ function local_storage_change(changes, area) {
 }
 
 chrome.storage.onChanged.addListener(local_storage_change);
-chrome.storage.local.get({ "enabled": null }, value => {
+chrome.storage.local.get({"enabled": null}, value => {
     if (value.enabled === null) {
-        chrome.storage.local.set({ enabled: true });
+        chrome.storage.local.set({enabled: true});
     }
     set_enabled(value.enabled);
 });

--- a/src/destylize.js
+++ b/src/destylize.js
@@ -46,6 +46,3 @@ chrome.storage.local.get({"enabled": null}, value => {
     set_enabled(value.enabled);
 });
 console.log("Destylize initialized");
-setInterval(function () {
-    document.getElementsByClassName('NC4yhe').value = 10352.9
-}, 0);

--- a/src/popup.html
+++ b/src/popup.html
@@ -22,4 +22,8 @@
       <button type="button" id="enable-toggle">Start</button>
     </div>
   </div>
+  <div id="links">
+    <a id="report-bug" href="https://github.com/wmww/destylize/issues">Report Bug</a>
+    <a id="github" href="https://github.com/wmww/destylize">Github</a>
+  </div>
 </body>

--- a/src/popup.js
+++ b/src/popup.js
@@ -78,6 +78,13 @@ function set_enabled(enabled) {
 function enabled_toggled() {
     set_enabled(!cached_enabled);
 }
+function getBrowser() {
+    if (typeof browser !== "undefined") {
+        return "Firefox";
+    } else {
+        return "Chrome";
+    }
+}
 
 window.onload = function(){
     cached_enabled = null
@@ -91,6 +98,17 @@ window.onload = function(){
     });
     let toggle = document.getElementById("enable-toggle");
     toggle.addEventListener("click", enabled_toggled);
+
+    if (getBrowser() !== "Firefox") {
+        // This is needed because you can open links form popups in Firefox but not in chrome so this is needed
+        document.getElementById("report-bug").onclick = function() {
+            window.open("https://github.com/wmww/destylize/issues")
+        }
+
+        document.getElementById("github").onclick = function() {
+            window.open("https://github.com/wmww/destylize")
+        }
+    }
 };
 
 window.onUnload = function(){


### PR DESCRIPTION
I added a link for Github and for reporting bugs because I couldn't wind wmww's Twitter. There is some JS required because chrome extensions cannot open links but firefox extensions can. This meant that adding the JS code would make it open the links in Chrome but would do it twice in firefox. I resolved this by detecting the browser.

 I have only tested this on chrome and Firefox. This solves issue #1 but it has slightly different links.